### PR TITLE
Add missing order and normalize beer names

### DIFF
--- a/models/beers/beers.sql
+++ b/models/beers/beers.sql
@@ -4,12 +4,12 @@
 ) }}
 
 SELECT
-  id            AS beer_id,
-  TRIM(name)    AS beer_name,
-  style         AS beer_style,
-  abv           AS abv,
-  ibu           AS ibu,
-  brewery_id    AS brewery_id,
-  ounces        AS ounces
+  id                                             AS beer_id,
+  TRIM(REGEXP_REPLACE(name, '\\([0-9]+\\)', '')) AS beer_name,
+  style                                          AS beer_style,
+  abv                                            AS abv,
+  ibu                                            AS ibu,
+  brewery_id                                     AS brewery_id,
+  ounces                                         AS ounces
 FROM
   {{ ref('seed_beers') }}

--- a/models/beers/sales.sql
+++ b/models/beers/sales.sql
@@ -23,10 +23,10 @@ SELECT
  orders.created_at                          AS order_created_at,
  order_lines.quantity                       AS order_li_quantity,
  order_lines.price                          AS order_li_price_each,
- order_lines.quantity * order_lines.price   AS order_li_price_total
+ order_lines.quantity * order_lines.price   AS order_li_price_total,
+ 
+ orders.status = 'DELIVERED'                AS is_delivered
 
 FROM {{ ref('orders') }} orders
 JOIN {{ ref('order_lines') }} order_lines USING (order_no)
 JOIN {{ ref('beers_with_breweries') }} beers_with_breweries USING (beer_id)
-
-WHERE orders.status = 'DELIVERED'


### PR DESCRIPTION
Two changes in this PR:

- I found the missing orders. It looks like we only include the delivered orders in the sales table.
- Cleaned up the beer names a bit. Sometimes they have a year behind it: Alphadelic IPA (2011). It is better to normalize this to Alphadelic IPA.