### PR TITLE
[DAT-3856] orders_v2

### DIFF
--- a/models/beers/orders_generated.sql
+++ b/models/beers/orders_generated.sql
@@ -54,7 +54,7 @@ with dates as ( --generate dates for the last year
             + noise
             + month_of_year * 200 --increase orders over the course of the year
             + beer_holiday_constant * 150 --increase orders around holidays
-            + increasing_constant
+            + increasing_constant --general increase over time
         as seed_data_point
     from dates
 )

--- a/models/beers/orders_v2.sql
+++ b/models/beers/orders_v2.sql
@@ -1,0 +1,88 @@
+{{ config(
+    materialized='table',
+    persist_docs={"relation": true, "columns": true}
+) }}
+
+
+with dates as ( --generate dates for the last year
+  select
+  dateadd(day,-seq4(),current_date) as _date
+  from table(generator(rowcount => (365
+                                   )))
+)
+
+,generate_seasonal_data as (
+    select
+    _date
+    --date parts
+    ,quarter(_date) as quarter_of_year
+    ,month(_date) as month_of_year
+    ,weekofyear(_date) as week_of_year
+    ,dayofweek(_date) as day_of_week
+    ,dayofyear(_date) as day_of_year
+    ,_date - '2021-01-01'::date as increasing_constant
+    
+    ,500 as mean
+    ,1000 as offset
+    ,cos(day_of_year/365*52*pi()- pi() ) * mean + offset as cycle
+    
+    ,100 as noise_mean
+    ,250 as noise_var
+    
+    ,normal(noise_mean,noise_var,random()) as noise --normally distributed random #s
+    ,cycle 
+            + noise
+            --add date constants to have sales increase over the course of the year
+            + day_of_week
+            + week_of_year
+            + month_of_year * 200
+            + quarter_of_year
+            + increasing_constant --up and to the right constant
+        as seed_data_point
+    from dates
+)
+
+,daily_total_orders as (
+    select
+    _date as order_date
+    ,seed_data_point::int as total_orders
+    from generate_seasonal_data
+)
+
+,row_numbers as ( --generate a row numbers to be used to construct orders table
+    select row_number() over (order by seq4()) as row_num from table(generator(rowcount=>10000))
+)
+
+,order_rows as ( --use row_numbers and synthetic data to create a row for each order
+    select 
+    orders.order_date
+    ,row_numbers.row_num
+    from daily_total_orders as orders
+    inner join row_numbers on row_numbers.row_num <= orders.total_orders
+    order by 1,2
+)
+
+,orders_raw as ( --create order number and beer id
+    select
+    order_date
+    ,to_char(order_date,'yyyymmdd')||lpad(row_num,5,0) as order_number
+    ,normal(1000, 250, random())::int as beer_id --randomly generate beer id (normalized distribution; mean id 1000, dev 250)
+    from order_rows
+)
+
+select
+orders.order_date
+,orders.order_number
+,beers.beer_id
+,beers.beer_name
+,beers.beer_style
+,abv as beer_abv
+,breweries.brewery_id
+,breweries.brewery_name
+,breweries.brewery_state
+,breweries.brewery_country
+from orders_raw as orders
+inner join  {{ ref('beers') }} as beers
+    on orders.beer_id = beers.beer_id
+inner join  {{ ref('breweries') }} as breweries
+    on beers.brewery_id = breweries.brewery_id

--- a/models/beers/orders_v2.sql
+++ b/models/beers/orders_v2.sql
@@ -21,14 +21,13 @@ with dates as ( --generate dates for the last year
     ,dayofweek(_date) as day_of_week
     ,dayofyear(_date) as day_of_year
     ,_date - '2021-01-01'::date as increasing_constant
-    
+    --generate seasonal data using cosine
     ,500 as mean
     ,1000 as offset
     ,cos(day_of_year/365*52*pi()- pi() ) * mean + offset as cycle
-    
+    --add noise to seasonal data using normal function
     ,100 as noise_mean
     ,250 as noise_var
-    
     ,normal(noise_mean,noise_var,random()) as noise --normally distributed random #s
     ,cycle 
             + noise

--- a/models/beers/schema.yml
+++ b/models/beers/schema.yml
@@ -88,6 +88,16 @@ models:
         meta:
          primary-key: true
 
+  - name: orders_generated
+    description: Randomly generated order data
+    columns:
+      - name: order_number
+        tests:
+          - unique
+          - not_null
+        meta:
+         primary-key: true
+
   - name: order_lines
     columns:
       - name: order_no


### PR DESCRIPTION
This PR creates seasonal, random, normally distributed beer order data.

Intent is to use this to create better demo alerts:
<img width="1498" alt="Screen Shot 2022-08-11 at 5 26 16 PM" src="https://user-images.githubusercontent.com/40182913/184264134-bfe2e0ad-439e-4b9c-9101-c9be9600dc73.png">


```
dbt-beers [kyle-dat-3869-generate-new-seed-data●] dbt run -m orders_v2
00:23:59  Running with dbt=1.1.1
00:23:59  Found 8 models, 10 tests, 0 snapshots, 0 analyses, 392 macros, 0 operations, 2 seed files, 0 sources, 0 exposures, 0 metrics
00:23:59  
00:24:01  Concurrency: 10 threads (target='dev')
00:24:01  
00:24:01  1 of 1 START table model BEERS_KYLE.orders_v2 .................................. [RUN]
00:24:05  1 of 1 OK created table model BEERS_KYLE.orders_v2 ............................. [SUCCESS 1 in 4.79s]
00:24:05  
00:24:05  Finished running 1 table model in 6.69s.
00:24:05  
00:24:05  Completed successfully
00:24:05  
00:24:05  Done. PASS=1 WARN=0 ERROR=0 SKIP=0 TOTAL=1
```