### PR TITLE
[DAT-3869] data smoothing

### DIFF
--- a/models/beers/orders_generated.sql
+++ b/models/beers/orders_generated.sql
@@ -52,9 +52,13 @@ with dates as ( --generate dates for the last year
     ,normal(noise_mean,noise_var,random()) as noise --normally distributed random #s
     ,cycle 
             + noise
-            + month_of_year * 200 --increase orders over the course of the year
+            + month_of_year * 150 --increase orders over the course of the year
             + beer_holiday_constant * 150 --increase orders around holidays
             + increasing_constant --general increase over time
+            + case --new years smoothing
+                when day_of_year between 1 and 15 then 1000
+                when day_of_year between 16 and 40 then 500
+                else 0 end
         as seed_data_point
     from dates
 )


### PR DESCRIPTION
Smooth out generated orders data to improve anomaly detection fit to be tighter.

Specifically:
* decrease the weight assigned to `month of year`
* add constants to first days of the year

before:
<img width="1265" alt="Screen Shot 2022-08-15 at 10 51 47 AM" src="https://user-images.githubusercontent.com/40182913/184973260-cee8a118-f7e9-4e9b-93ec-8d386f304416.png">

after:
![Screen Shot 2022-08-16 at 12 57 46 PM](https://user-images.githubusercontent.com/40182913/184973370-0a204acb-9512-4bea-b8c5-c4f66512149d.png)

